### PR TITLE
feat: Add redirect for /resume to Google Doc

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "redirects": [
+    {
+      "source": "/resume",
+      "destination": "https://docs.google.com/document/d/1h2I8FLRlOW4u3TrikLd5v2I6w12hF81T_4h-pKg8-0c/edit?usp=sharing",
+      "permanent": true
+    }
+  ]
+}


### PR DESCRIPTION
This commit introduces a redirect rule in `vercel.json`. When you navigate to `/resume` on the website, you will be redirected to the owner's resume hosted on Google Docs.

The redirect is permanent (HTTP 308).